### PR TITLE
Fixed RCE in node-tool-utils

### DIFF
--- a/lib/tool.js
+++ b/lib/tool.js
@@ -267,6 +267,7 @@ exports.openBrowser = (port, url) => {
 
 exports.checkPortUsed = port => {
   let cmd = '';
+  port = parseInt(port);
   switch (os.platform()) {
     case 'win32':
       cmd = `netstat -ano | findstr ${port}`;


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-tool-utils/

### ⚙️ Description *
The ```node-tool-utils``` module is vulnerable against ```RCE``` since a command is crafted using user inputs not validated and then executedading to ```arbitrary command injection```

### 💻 Technical Description *
Fixed RCE by parsing the user input as integer. The ```port``` parameter should only accept integer input and not a string. So used ```parseInt()``` function to convert the given string to integer. 

### 🐛 Proof of Concept (PoC) *
```
const tool = require('node-tool-utils');
tool.checkPortUsed("test; touch HACKED; #"); //The *port* parameter should be numeric and inserted as 2' argument of
```
![poc](https://user-images.githubusercontent.com/29670330/92588140-2cee3600-f2b6-11ea-8efc-bcea613ceadd.png)

### 🔥 Proof of Fix (PoF) *
Added ```parseInt()``` in the ```port``` parameter.  Parse the input string to integer. 
![pof](https://user-images.githubusercontent.com/29670330/92588153-311a5380-f2b6-11ea-81ee-17046c60f090.png)

### 👍 User Acceptance Testing (UAT)
App seems to be working fine. OK 
